### PR TITLE
feat: allow private key to be supplied in file

### DIFF
--- a/tradetrust/document-store-worker/src/config/__init__.py
+++ b/tradetrust/document-store-worker/src/config/__init__.py
@@ -64,7 +64,10 @@ class Config:
             'ABI': Config.load_json_file(os.environ['DOCUMENT_STORE_ABI'])['abi'],
             'Owner': {
                 'PublicKey': os.environ['DOCUMENT_STORE_OWNER_PUBLIC_KEY'],
-                'PrivateKey': os.environ['DOCUMENT_STORE_OWNER_PRIVATE_KEY']
+                'PrivateKey': Config.get_env_or_singleline_file_value(
+                                    'DOCUMENT_STORE_OWNER_PRIVATE_KEY',
+                                    not_empty=True
+                )
             }
         }
 


### PR DESCRIPTION
Workaround to remove the requirement to pass a cleartext private key via an env var