### PR TITLE
feat(openatt): add gas price config support

### DIFF
--- a/tradetrust/document-store-contract/Dockerfile
+++ b/tradetrust/document-store-contract/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:12-alpine
 
 
 WORKDIR /document-store-contract

--- a/tradetrust/document-store-worker/src/config/__init__.py
+++ b/tradetrust/document-store-worker/src/config/__init__.py
@@ -53,7 +53,9 @@ class Config:
         )
 
         blockchain = {
-            'Endpoint': os.environ['BLOCKCHAIN_ENDPOINT']
+            'Endpoint': os.environ['BLOCKCHAIN_ENDPOINT'],
+            'GasPrice' : os.environ.get('BLOCKCHAIN_GAS_PRICE', None ),
+            'ReceiptTimeout' : int(os.environ.get('BLOCKCHAIN_RECEIPT_TIMEOUT', 180))
         }
 
         document_store = {

--- a/tradetrust/document-store-worker/src/worker/__init__.py
+++ b/tradetrust/document-store-worker/src/worker/__init__.py
@@ -33,7 +33,7 @@ class Worker:
 
     def eth_connect(self):
         logger.debug('eth_connect')
-        self.web3 = Web3(Web3.HTTPProvider(config['Endpoint']))
+        self.web3 = Web3(Web3.HTTPProvider(self.config['Blockchain']['Endpoint']))
 
         logger.info(
             'Worker connected to blockchain node at %s, '


### PR DESCRIPTION
Adds support for setting the GasPrice for transactions. At the moment they are being set quite a low price which means that they take some time to be added to a busy network 

This wasn't an issue on local testing or testnet as they are quiet, on mainnent the current price means transactions can take up to a couple of hours 