### PR TITLE
WIP: document store worker pending transactions handling updates

### DIFF
--- a/tradetrust/docker-compose.servers.yml
+++ b/tradetrust/docker-compose.servers.yml
@@ -161,6 +161,8 @@ services:
       OPEN_ATTESTATION_ENDPOINT: http://open-attestation-api:9090
 
       BLOCKCHAIN_ENDPOINT: http://tradetrust-ganache-cli:8585
+      BLOCKCHAIN_GAS_PRICE: fast
+      BLOCKCHAIN_GAS_PRICE_REFRESH_RATE: 10
 
       AWS_ENDPOINT_URL: http://tradetrust-localstack:10001
       AWS_ACCESS_KEY_ID: access

--- a/tradetrust/docker-compose.yml
+++ b/tradetrust/docker-compose.yml
@@ -167,6 +167,8 @@ services:
       OPEN_ATTESTATION_ENDPOINT: /aws/oa-api.endpoint
 
       BLOCKCHAIN_ENDPOINT: http://tradetrust-ganache-cli:8585
+      BLOCKCHAIN_GAS_PRICE: fast
+      BLOCKCHAIN_GAS_PRICE_REFRESH_RATE: 10
 
       AWS_ENDPOINT_URL: http://tradetrust-localstack:10001
       AWS_ACCESS_KEY_ID: access

--- a/tradetrust/document-store-worker/src/config/__init__.py
+++ b/tradetrust/document-store-worker/src/config/__init__.py
@@ -55,7 +55,8 @@ class Config:
 
         blockchain = {
             'Endpoint': os.environ['BLOCKCHAIN_ENDPOINT'],
-            'GasPrice': os.environ.get('BLOCKCHAIN_GAS_PRICE', None),
+            'GasPrice': os.environ.get('BLOCKCHAIN_GAS_PRICE', 'medium'),
+            'GasPriceRefreshRate': int(os.environ.get('BLOCKCHAIN_GAS_PRICE_REFRESH_RATE', 10)),
             'ReceiptTimeout': int(os.environ.get('BLOCKCHAIN_RECEIPT_TIMEOUT', 180))
         }
 

--- a/tradetrust/document-store-worker/tests/data/__init__.py
+++ b/tradetrust/document-store-worker/tests/data/__init__.py
@@ -1,0 +1,9 @@
+from string import Template
+
+
+with open('/document-store-worker/tests/data/document.v2.json', 'rt') as f:
+    DOCUMENT_V2_TEMPLATE = Template(f.read())
+
+
+with open('/document-store-worker/tests/data/document.v3.json', 'rt') as f:
+    DOCUMENT_V3_TEMPLATE = Template(f.read())

--- a/tradetrust/document-store-worker/tests/integration/test.py
+++ b/tradetrust/document-store-worker/tests/integration/test.py
@@ -2,9 +2,9 @@ import os
 import time
 import json
 from unittest import mock
-from string import Template
 from src.config import Config
 from src.worker import Worker
+from tests.data import DOCUMENT_V2_TEMPLATE, DOCUMENT_V3_TEMPLATE
 
 
 @mock.patch.dict(
@@ -20,15 +20,15 @@ def test(unprocessed_queue, unprocessed_bucket, issued_bucket, unwrap, wrap):
     # overriding safe VisibilityTimeout
     config['Worker']['Polling']['VisibilityTimeout'] = 1
     queue_test_wait_time_seconds = config['Worker']['Polling']['VisibilityTimeout'] * 2
-    with open('/document-store-worker/tests/data/document.v2.json', 'rt') as f:
-        document_v2 = Template(f.read()).substitute(DocumentStoreAddress=document_store_address)
-        document_v2 = json.loads(document_v2)
-        wrapped_document_v2 = wrap(document_v2, '2.0')
 
-    with open('/document-store-worker/tests/data/document.v3.json', 'rt') as f:
-        document_v3 = Template(f.read()).substitute(DocumentStoreAddress=document_store_address)
-        document_v3 = json.loads(document_v3)
-        wrapped_document_v3 = wrap(document_v3, '3.0')
+    document_v2 = DOCUMENT_V2_TEMPLATE.substitute(DocumentStoreAddress=document_store_address)
+    document_v2 = json.loads(document_v2)
+    wrapped_document_v2 = wrap(document_v2, '2.0')
+
+    document_v3 = DOCUMENT_V3_TEMPLATE.substitute(DocumentStoreAddress=document_store_address)
+    document_v3 = json.loads(document_v3)
+    wrapped_document_v3 = wrap(document_v3, '3.0')
+
     worker = Worker(config)
     index = 1
     # checking both schema versions to test auto version definition

--- a/tradetrust/document-store-worker/tests/unit/test.py
+++ b/tradetrust/document-store-worker/tests/unit/test.py
@@ -165,9 +165,9 @@ def test_validate_document_schema(requests):
 
 
 @mock.patch('src.worker.Web3.toJSON')
-@mock.patch('src.worker.Worker._create_issue_document_transaction')
-@mock.patch('src.worker.Worker._wait_for_transaction_receipt')
-def test_issue_document_transaction_error(_wait_for_transaction_receipt, _create_issue_document_transaction, toJSON):
+@mock.patch('src.worker.Worker.create_issue_document_transaction')
+@mock.patch('src.worker.Worker.wait_for_transaction_receipt')
+def test_issue_document_transaction_error(wait_for_transaction_receipt, create_issue_document_transaction, toJSON):
     config = Config.from_environ()
     worker = Worker(config)
     wrapped_document = {}
@@ -176,13 +176,13 @@ def test_issue_document_transaction_error(_wait_for_transaction_receipt, _create
     receipt = mock.MagicMock
     receipt.status = 0
     toJSON.return_value = {'receipt': {'id': 1}}
-    _create_issue_document_transaction.return_value = tx_hash
-    _wait_for_transaction_receipt.return_value = receipt
+    create_issue_document_transaction.return_value = tx_hash
+    wait_for_transaction_receipt.return_value = receipt
     with pytest.raises(RuntimeError) as einfo:
         worker.issue_document(wrapped_document)
     assert str(einfo.value) == json.dumps(toJSON.return_value)
-    _create_issue_document_transaction.assert_called_once_with(wrapped_document)
-    _wait_for_transaction_receipt.assert_called_once_with(tx_hash)
+    create_issue_document_transaction.assert_called_once_with(wrapped_document)
+    wait_for_transaction_receipt.assert_called_once_with(tx_hash)
     toJSON.assert_called_once_with(receipt)
 
 

--- a/tradetrust/document-store-worker/tests/unit/test_gas_price_adjustment.py
+++ b/tradetrust/document-store-worker/tests/unit/test_gas_price_adjustment.py
@@ -1,0 +1,96 @@
+import json
+from unittest import mock
+import pytest
+from web3.exceptions import TimeExhausted
+from src.config import Config
+from src.worker import Worker
+from src.worker import fast_gas_price_strategy, medium_gas_price_strategy
+from tests.data import DOCUMENT_V2_TEMPLATE
+
+
+def connect_resources(self):
+    self.web3 = mock.MagicMock()
+    self.unprocessed_queue = mock.MagicMock()
+    self.unprocessed_bucket = mock.MagicMock()
+    self.issued_bucket = mock.MagicMock()
+    self.document_store = mock.MagicMock()
+
+
+@mock.patch('src.worker.Worker.connect_resources', connect_resources)
+def test_initialization():
+    config = Config.from_environ()
+    config['Blockchain']['GasPrice'] = 'fast'
+
+    worker = Worker(config)
+    worker.web3.eth.setGasPriceStrategy.assert_called_once_with(fast_gas_price_strategy)
+    assert worker.dynamic_gas_price_strategy
+    assert worker.gas_price == worker.web3.eth.generateGasPrice()
+
+    config['Blockchain']['GasPrice'] = 'medium'
+    worker = Worker(config)
+    worker.web3.eth.setGasPriceStrategy.assert_called_once_with(medium_gas_price_strategy)
+    assert worker.dynamic_gas_price_strategy
+    assert worker.gas_price == worker.web3.eth.generateGasPrice()
+
+    config['Blockchain']['GasPrice'] = 6000000
+    worker = Worker(config)
+    assert not worker.dynamic_gas_price_strategy
+    assert worker.gas_price == config['Blockchain']['GasPrice']
+    worker.web3.eth.setGasPriceStrategy.assert_not_called()
+
+    config['Blockchain']['GasPrice'] = 'slow'
+    with pytest.raises(Exception) as einfo:
+        worker = Worker(config)
+    assert str(einfo.value) == 'Invalid gas price strategy:\'slow\''
+
+    config['Blockchain']['GasPrice'] = None
+    with pytest.raises(Exception) as einfo:
+        worker = Worker(config)
+    assert str(einfo.value) == 'Invalid gas price strategy:None'
+
+
+@mock.patch('src.worker.Worker.connect_resources', connect_resources)
+@mock.patch('src.worker.Worker.load_unprocessed_document')
+def test_gas_price_update(load_unprocessed_document):
+
+    config = Config.from_environ()
+    config['Blockchain']['GasPrice'] = 'fast'
+    config['Blockchain']['GasPriceRefreshRate'] = 2
+
+    key = 'document-key'
+    document = DOCUMENT_V2_TEMPLATE.substitute(DocumentStoreAddress=config['DocumentStore']['Address'])
+    document = json.loads(document)
+    load_unprocessed_document.return_value = key, document
+
+    message = mock.Mock()
+    message.body = json.dumps({'Records': [{}]})
+
+    worker = Worker(config)
+
+    worker.web3.eth.sendRawTransaction.return_value = b'transaction-hash'
+    worker.web3.eth.waitForTransactionReceipt().status = 1
+
+    # testing transaction timeout causing gas price update
+    worker.web3.reset_mock()
+    worker.web3.eth.waitForTransactionReceipt.side_effect = TimeExhausted
+    assert not worker.process_message(message)
+    worker.web3.eth.generateGasPrice.assert_called_once()
+
+    # testing gas price refresh
+    worker.web3.reset_mock()
+    worker.web3.eth.waitForTransactionReceipt.side_effect = None
+    for i in range(config['Blockchain']['GasPriceRefreshRate']):
+        assert worker.process_message(message)
+    worker.web3.eth.generateGasPrice.assert_called_once()
+
+    # testing no refresh on static gas price
+    config['Blockchain']['GasPrice'] = 20
+    worker = Worker(config)
+
+    worker.web3.eth.sendRawTransaction.return_value = b'transaction-hash'
+    worker.web3.eth.waitForTransactionReceipt().status = 1
+
+    worker.web3.reset_mock()
+    for i in range(config['Blockchain']['GasPriceRefreshRate']):
+        assert worker.process_message(message)
+    worker.web3.eth.generateGasPrice.assert_not_called()


### PR DESCRIPTION
https://github.com/gs-gs/ha-igl-p2/issues/468
https://github.com/gs-gs/ha-igl-p2/issues/469
https://github.com/gs-gs/ha-igl-p2/issues/343

Hash duplication problem solved by solving transactions duplication problem by removing pending transactions number from nonce calculation. 
Added 3 gas price strategies:
1. static - integer value in wei
1. fast - 60 sec
1. medium - 5 min

Added gas price refresh to avoid overpaying for transactions. By default gas price will be refreshed each 10th transaction. 

That's still one problem I think of, it's related to the rare occurrence of a stuck transaction being mined before a higher-paid one. 
Because of the same nonce it will replace the newer transaction and as a result, a  document will remain in an unprocessed bucket forever. It's related only to already wrapped documents because their signature is constant, therefore, a probable solution is adding ```isIssued``` check for the wrapped documents before processing them. 

UPDATE:
I've added a solution to the problem mentioned above. 