### PR TITLE
FIX: updated localstack configuration for newer localstack version

### DIFF
--- a/tradetrust/docker-compose.servers.yml
+++ b/tradetrust/docker-compose.servers.yml
@@ -18,7 +18,6 @@ services:
       SERVICES: sqs,s3,iam,cloudwatch
       DEFAULT_REGION: us-east-1
 
-      AWS_DEFAULT_REGION: us-east-1
       AWS_ACCESS_KEY_ID: access
       AWS_SECRET_ACCESS_KEY: secretaccess
 

--- a/tradetrust/docker-compose.yml
+++ b/tradetrust/docker-compose.yml
@@ -19,7 +19,6 @@ services:
       SERVICES: sqs,s3,iam,lambda,apigateway,cloudwatch
       DEFAULT_REGION: us-east-1
 
-      AWS_DEFAULT_REGION: us-east-1
       AWS_ACCESS_KEY_ID: access
       AWS_SECRET_ACCESS_KEY: secretaccess
 

--- a/tradetrust/localstack/0-deploy-apigateway-lambda.sh
+++ b/tradetrust/localstack/0-deploy-apigateway-lambda.sh
@@ -70,7 +70,7 @@ function deploy_apigateway_lambda(){
     --http-method ANY \
     --type AWS_PROXY \
     --integration-http-method POST \
-    --uri arn:aws:apigateway:${AWS_DEFAULT_REGION}:lambda:path/2015-03-31/functions/${LAMBDA_ARN}/invocations \
+    --uri arn:aws:apigateway:${DEFAULT_REGION}:lambda:path/2015-03-31/functions/${LAMBDA_ARN}/invocations \
     --passthrough-behavior WHEN_NO_MATCH
   echo "Done"
   echo "Deploying api gateway"
@@ -81,7 +81,7 @@ function deploy_apigateway_lambda(){
 
   echo "Saving API endpoint..."
 
-  ENDPOINT=http://${HOSTNAME_EXTERNAL}:4567/restapis/${API_ID}/test/_user_request_/
+  ENDPOINT=http://${HOSTNAME_EXTERNAL}:10001/restapis/${API_ID}/test/_user_request_/
 
   echo "$ENDPOINT" > $API_ENDPOINT_FILENAME
   echo "ENDPOINT=$ENDPOINT saved to $API_ENDPOINT_FILENAME"


### PR DESCRIPTION
@arpentnoir Localstack updated its configuration and behavior a little bit in the newest version. I updated related values and now everything works fine. Anyway, I recommend running everything with ```make run-on-servers``` because it's simply faster. And original ```docker-compose.yml``` probably will be replaced with the servers one in the future because lambda emulation mechanism isn't good enough to use it.