### PR TITLE
feat: replace new jobs if already running

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,6 @@ pipeline {
     stages {
 
         stage('Cancel running builds') {
-            agent none
             steps {
                 milestone label: '', ordinal:  Integer.parseInt(env.BUILD_ID) - 1
                 milestone label: '', ordinal:  Integer.parseInt(env.BUILD_ID)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,8 @@ pipeline {
                 numToKeepStr: '20'
             )
         )
-        skipDefaultCheckout()
+        // Checkout the repo so we can determine change log
+        checkoutToSubdirectory('.changelog')
     }
 
     parameters {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,6 +37,14 @@ pipeline {
     }
 
     stages {
+
+        stage('Cancel running builds') {
+            steps {
+                milestone label: '', ordinal:  Integer.parseInt(env.BUILD_ID) - 1
+                milestone label: '', ordinal:  Integer.parseInt(env.BUILD_ID)
+            }
+        }
+
         stage('Testing') {
 
             stages {
@@ -186,7 +194,6 @@ pipeline {
                     }
 
                     steps {
-
                         dir('.hamlet/cmdb') {
                             script {
                                 git changelog: false, credentialsId: 'github', poll: false, url: "${env["product_cmdb"]}", branch: "${env["product_cmdb_branch"]}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,7 @@ pipeline {
     stages {
 
         stage('Cancel running builds') {
+            agent none
             steps {
                 milestone label: '', ordinal:  Integer.parseInt(env.BUILD_ID) - 1
                 milestone label: '', ordinal:  Integer.parseInt(env.BUILD_ID)


### PR DESCRIPTION
Fix for https://github.com/gs-gs/ha-igl-project/issues/205  which will cancel any existing running jobs if a new instance of the job is started. 

If commits come through in quick succession then we repeat all of the steps for both jobs which means that jobs can get out of sync. 

This will cancel existing jobs and only run the latest commit through the deployment pipeline