### PR TITLE
DONE: verify-api 500 error when a network is unavailable

### DIFF
--- a/tradetrust/open-attestation-verify-api/src/app.js
+++ b/tradetrust/open-attestation-verify-api/src/app.js
@@ -85,6 +85,9 @@ function create(){
 
   app.post('/verify', upload.single('file'), async function (req, res, next){
     async function handler(){
+      // check that the node connection is active
+      // it will throw an error if something went wrong while getting network details
+      await VERIFY_OPTIONS.provider.getNetwork();
       const document = getDocumentJSON(req);
       const fragments = await verify(document);
       const valid = isValid(fragments);
@@ -96,6 +99,9 @@ function create(){
 
   app.post('/verify/fragments', upload.single('file'), async function(req, res, next){
     async function handler(){
+      // check that the node connection is active
+      // it will throw an error if something went wrong while getting network details
+      await VERIFY_OPTIONS.provider.getNetwork();
       const document = getDocumentJSON(req);
       const fragments = await verify(document);
       res.status(200).send(fragments);


### PR DESCRIPTION
So, everything is very simple. I added an attempt to get network details before the verification. If a provider can't connect to a network it throws an error that will be cathed by the error handler.  I tested this manually, works as expected. 