### PR TITLE
refactor(cd): move to using hamlet cli for full deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,6 @@ pipeline {
                 numToKeepStr: '20'
             )
         )
-        // Checkout the repo so we can determine change log
         skipDefaultCheckout()
     }
 
@@ -27,14 +26,6 @@ pipeline {
             defaultValue: false,
             description: 'Skip QA for open attestation components'
         )
-    }
-
-    environment {
-        deploy_stream_job = credentials('deploy_stream_job')
-        slack_channel = credentials('slack_channel')
-        properties_file = credentials('properties_file')
-        product_cmdb = credentials('product_cmdb')
-        product_cmdb_branch = credentials('product_cmdb_branch')
     }
 
     stages {
@@ -157,101 +148,132 @@ pipeline {
                     }
                 }
             }
+
+            post {
+                cleanup {
+                    cleanWs()
+                }
+            }
         }
 
-        stage('Artefact') {
+        stage('deploy') {
+
+            environment {
+                ROOT_DIR = "${WORKSPACE}/cmdb"
+                SEGMENT = 'clients'
+            }
+
             stages{
+
+                stage ('setup') {
+                    steps {
+                        withFolderProperties {
+                            dir('cmdb/') {
+                                git(
+                                    credentialsId: 'github',
+                                    changelog: false,
+                                    poll: false,
+                                    url: env.product_cmdb_url,
+                                    branch: env.product_cmdb_branch
+                                )
+                            }
+
+                            dir('code/') {
+                                script {
+                                    repo = checkout scm
+                                    env["GIT_COMMIT"] = repo.GIT_COMMIT
+                                }
+                            }
+
+                            sh '''
+                                pip install -q --upgrade hamlet
+                                hamlet engine install-engine --update tram
+                                hamlet engine set-engine tram
+                            '''
+
+                            // Make folder properties available for rest of deploy jobs
+                            withFolderProperties{
+                                script {
+                                    env['TENANT'] = env.TENANT
+                                    env['PRODUCT'] = env.PRODUCT
+                                    env['ACCOUNT'] = env.ACCOUNT
+                                    env['ENVIRONMENT'] = env.ENVIRONMENT
+
+                                    env['HAMLET_AWS_AUTH_SOURCE'] = env.HAMLET_AWS_AUTH_SOURCE
+                                    env['HAMLET_AWS_AUTH_USER'] = env.HAMLET_AWS_AUTH_USER
+
+                                    env['slack_channel'] = env.slack_channel
+
+                                    env['product_cmdb_branch'] = env.product_cmdb_branch
+                                    env['product_cmdb_url'] = env.product_cmdb_url
+                                    env['account_cmdb_branch'] = env.account_cmdb_branch
+                                    env['account_cmdb_url'] = env.account_cmdb_url
+                                }
+                            }
+                        }
+                    }
+
+                }
+
                 stage('trade_portal') {
                     when {
                         anyOf {
                             equals expected: true, actual: params.force_deploy
-                            branch 'master'
-                            branch 'main'
-                        }
-                    }
-
-                    environment {
-                        //hamlet deployment variables
-                        DEPLOYMENT_UNITS = 'www-trd,www-task-trd,www-work-trd,www-util-trd'
-                        SEGMENT = 'clients'
-                        BUILD_PATH = 'artefact/trade_portal/'
-                        DOCKER_CONTEXT_DIR = 'artefact/trade_portal/trade_portal/'
-                        BUILD_SRC_DIR = ''
-                        DOCKER_FILE = 'artefact/trade_portal/trade_portal/compose/production/django/Dockerfile'
-                        GENERATION_CONTEXT_DEFINED = ''
-
-                        image_format = 'docker'
-                    }
-
-                    steps {
-                        dir('.hamlet/cmdb') {
-                            script {
-                                git changelog: false, credentialsId: 'github', poll: false, url: "${env["product_cmdb"]}", branch: "${env["product_cmdb_branch"]}"
-                                def productProperties = readProperties interpolate: true, file: "${properties_file}" ;
-                                productProperties.each{ k, v -> env["${k}"] ="${v}" }
-
-                                if( "${env["AWS_AUTOMATION_USER"]}" == "HA" ) {
-                                    withCredentials([usernamePassword(credentialsId: 'aws', usernameVariable: 'aws_access_key', passwordVariable: 'aws_secret_key')]) {
-                                        env["HA_AWS_ACCESS_KEY_ID"] = "${env["aws_access_key"]}"
-                                        env["HA_AWS_SECRET_ACCESS_KEY"] = "${env["aws_secret_key"]}"
-                                    }
+                            allOf {
+                                anyOf {
+                                    branch 'master'
+                                    branch 'main'
+                                    branch 'cd_*'
+                                }
+                                anyOf {
+                                    changeset 'trade_portal/**'
+                                    changeset 'Jenkinsfile'
                                 }
                             }
                         }
+                    }
 
-                        dir('artefact/trade_portal/') {
-                            script {
-                                repo = checkout scm
-                                env["GIT_COMMIT"] = repo.GIT_COMMIT
-                            }
-                        }
-
-                        dir('artefact/trade_portal/trade_portal') {
-                            sh '''
+                    steps {
+                        dir('code/trade_portal') {
+                            sh '''#!/bin/bash
                                 npm ci
                                 npm run build
                             '''
+
+
+                            sh '''#!/bin/bash
+                                hamlet release upload-image -u www-trd -f docker -r "${GIT_COMMIT}" \
+                                    --dockerfile compose/production/django/Dockerfile --docker-context .
+
+                                hamlet release update-image-reference -u www-trd -f docker -r "${GIT_COMMIT}"
+                            '''
+
+                            sh '''#!/bin/bash
+                                # Running migration before deploy
+                                hamlet deploy run-deployments -u www-task-trd
+                                hamlet run task -t application -i app-ecs \
+                                        -w www-task -x trade -y "" -c www \
+                                        -e APP_TASK_LIST -v "migrate --no-input"
+
+                                # Running deploy of other units
+                                hamlet deploy run-deployments -u www-trd -u www-work-trd -u www-util-trd
+                            '''
                         }
-
-                        sh '''#!/bin/bash
-                        ${AUTOMATION_BASE_DIR}/setContext.sh || exit $?
-                        '''
-
-                        script {
-                            def contextProperties = readProperties interpolate: true, file: "${WORKSPACE}/context.properties";
-                            contextProperties.each{ k, v -> env["${k}"] ="${v}" }
-                        }
-
-                        sh '''#!/bin/bash
-                        ${AUTOMATION_DIR}/manageImages.sh -g "${GIT_COMMIT}" -f "${image_format}"  || exit $?
-                        '''
-
-                        script {
-                            def contextProperties = readProperties interpolate: true, file: "${WORKSPACE}/context.properties";
-                            contextProperties.each{ k, v -> env["${k}"] ="${v}" }
-                        }
-
-                        build job: "${env["deploy_stream_job"]}", wait: false, parameters: [
-                                extendedChoice(name: 'DEPLOYMENT_UNITS', value: "${env.DEPLOYMENT_UNITS}"),
-                                string(name: 'GIT_COMMIT', value: "${env.GIT_COMMIT}"),
-                                string(name: 'IMAGE_FORMATS', value: "${env.image_format}"),
-                                string(name: 'SEGMENT', value: "${env["SEGMENT"]}")
-                        ]
                     }
 
                     post {
                         success {
                             slackSend (
-                                message: "*Success* | <${BUILD_URL}|${JOB_NAME}> \n trade_portal artefact completed",
-                                channel: "${env["slack_channel"]}",
+                                message: "*Success* | <${BUILD_URL}|${JOB_NAME}> \n trade_portal deployment completed",
+                                channel: env.slack_channel,
                                 color: "#50C878"
                             )
                         }
 
                         failure {
                             slackSend (
-                                message: "*Failure* | <${BUILD_URL}|${JOB_NAME}> \n trade_portal artefact failed",
-                                channel: "${env["slack_channel"]}",
+                                message: "*Failure* | <${BUILD_URL}|${JOB_NAME}> \n trade_portal deployment completed",
+                                channel: env.slack_channel,
                                 color: "#B22222"
                             )
                         }
@@ -263,288 +285,138 @@ pipeline {
                     when {
                         anyOf {
                             equals expected: true, actual: params.force_deploy
-                            branch 'master'
-                            branch 'main'
+                            allOf {
+                                anyOf {
+                                    branch 'master'
+                                    branch 'main'
+                                    branch 'cd_*'
+                                }
+                                anyOf {
+                                    changeset 'tradetrust/**'
+                                    changeset 'Jenkinsfile'
+                                }
+                            }
                         }
                     }
 
                     stages{
-                        stage('Setup') {
-                            steps {
-                                dir('artefact/tradetrust/') {
-                                    script {
-                                        def productProperties = readProperties interpolate: true, file: "${env.properties_file}";
-                                        productProperties.each{ k, v -> env["${k}"] ="${v}" }
-
-                                        repo = checkout scm
-                                        env["GIT_COMMIT"] = repo.GIT_COMMIT
-                                    }
-                                }
-                            }
-                        }
-
                         stage('openatt-api') {
-                            environment {
-                                //hamlet deployment variables
-                                DEPLOYMENT_UNITS = 'openatt-api'
-                                SEGMENT = 'clients'
-                                BUILD_PATH = 'artefact/tradetrust/tradetrust/open-attestation-api/'
-                                BUILD_SRC_DIR = ''
-                                GENERATION_CONTEXT_DEFINED = ''
-
-                                image_format = 'openapi'
-                            }
-
                             steps {
-
-                                dir('artefact/tradetrust/tradetrust/open-attestation-api/') {
+                                dir('code/tradetrust/open-attestation-api/') {
                                     sh '''
-                                    npm install swagger-cli --no-save
-                                    npx swagger-cli bundle --dereference --outfile openapi-extended-base.json --type json api.yml
-                                    npx swagger-cli validate openapi-extended-base.json
+                                        npx swagger-cli bundle --dereference --outfile build/openapi-extended-base.json --type json api.yml
+                                        npx swagger-cli validate build/openapi-extended-base.json
+                                    '''
 
-                                    zip -j "openapi.zip" "openapi-extended-base.json"
-                                    mkdir -p src/dist/
-                                    cp "openapi.zip" src/dist/openapi.zip
+                                    sh '''
+                                        hamlet release upload-image -u openatt-api -f openapi -r "${GIT_COMMIT}" \
+                                            --image-path build/
+
+                                        hamlet release update-image-reference -u openatt-api -f openapi -r "${GIT_COMMIT}"
+                                    '''
+
+                                    sh '''
+                                        hamlet deploy run-deployments -u openatt-api
                                     '''
                                 }
-                                sh '''#!/bin/bash
-                                ${AUTOMATION_BASE_DIR}/setContext.sh || exit $?
-                                '''
-
-                                script {
-                                    def contextProperties = readProperties interpolate: true, file: "${WORKSPACE}/context.properties";
-                                    contextProperties.each{ k, v -> env["${k}"] ="${v}" }
-                                }
-
-                                sh '''#!/bin/bash
-                                ${AUTOMATION_DIR}/manageImages.sh -g "${GIT_COMMIT}" -f "${image_format}"  || exit $?
-                                '''
-
-                                script {
-                                    def contextProperties = readProperties interpolate: true, file: "${WORKSPACE}/context.properties";
-                                    contextProperties.each{ k, v -> env["${k}"] ="${v}" }
-                                }
-                                build job: "${env["deploy_stream_job"]}", wait: false, parameters: [
-                                        extendedChoice(name: 'DEPLOYMENT_UNITS', value: "${env.DEPLOYMENT_UNITS}"),
-                                        string(name: 'GIT_COMMIT', value: "${env.GIT_COMMIT}"),
-                                        string(name: 'IMAGE_FORMATS', value: "${env.image_format}"),
-                                        string(name: 'SEGMENT', value: "${env["SEGMENT"]}")
-                                ]
                             }
                         }
 
                         stage('openatt-api-imp') {
-                            environment {
-                                //hamlet deployment variables
-                                DEPLOYMENT_UNITS = 'openatt-api-imp'
-                                SEGMENT = 'clients'
-                                BUILD_PATH = 'artefact/tradetrust/tradetrust/open-attestation-api'
-                                BUILD_SRC_DIR = ''
-                                GENERATION_CONTEXT_DEFINED = ''
-
-                                image_format = 'lambda'
-                            }
-
                             steps {
 
-                                dir('artefact/tradetrust/tradetrust/open-attestation-api') {
+                                dir('code/tradetrust/open-attestation-api') {
                                     sh '''#!/bin/bash
                                         npm ci
                                         npx serverless package
-                                        mkdir -p src/dist
-                                        cp .serverless/openatt-api.zip src/dist/lambda.zip
                                     '''
+
+                                    sh '''#!/bin/bash
+                                        hamlet release upload-image -u openatt-api-imp -f lambda \
+                                            -r "${GIT_COMMIT}" --image-path .serverless/openatt-api.zip
+
+                                        hamlet release update-image-reference -u openatt-api-imp -f lambda \
+                                            -r "${GIT_COMMIT}"
+                                    '''
+
+                                    sh '''#!/bin/bash
+                                        hamlet deploy run-deployments -u openatt-api-imp
+                                    '''
+
                                 }
-
-                                sh '''#!/bin/bash
-                                ${AUTOMATION_BASE_DIR}/setContext.sh || exit $?
-                                '''
-
-                                script {
-                                    def contextProperties = readProperties interpolate: true, file: "${WORKSPACE}/context.properties";
-                                    contextProperties.each{ k, v -> env["${k}"] ="${v}" }
-                                }
-
-                                sh '''#!/bin/bash
-                                ${AUTOMATION_DIR}/manageImages.sh -g "${GIT_COMMIT}" -f "${image_format}"  || exit $?
-                                '''
-
-                                script {
-                                    def contextProperties = readProperties interpolate: true, file: "${WORKSPACE}/context.properties";
-                                    contextProperties.each{ k, v -> env["${k}"] ="${v}" }
-                                }
-
-                                build job: "${env["deploy_stream_job"]}", wait: false, parameters: [
-                                        extendedChoice(name: 'DEPLOYMENT_UNITS', value: "${env.DEPLOYMENT_UNITS}"),
-                                        string(name: 'GIT_COMMIT', value: "${env.GIT_COMMIT}"),
-                                        string(name: 'IMAGE_FORMATS', value: "${env.image_format}"),
-                                        string(name: 'SEGMENT', value: "${env["SEGMENT"]}")
-                                ]
                             }
                         }
 
                         stage('openatt-worker') {
-
-                            environment {
-                                //hamlet deployment variables
-                                DEPLOYMENT_UNITS = 'openatt-worker,openatt-contract'
-                                SEGMENT = 'clients'
-                                BUILD_PATH = 'artefact/tradetrust/tradetrust/ts-document-store-worker'
-                                BUILD_SRC_DIR = ''
-                                DOCKER_CONTEXT_DIR = 'artefact/tradetrust/tradetrust/ts-document-store-worker'
-                                DOCKER_FILE = 'artefact/tradetrust/tradetrust/ts-document-store-worker/Dockerfile'
-                                GENERATION_CONTEXT_DEFINED = ''
-
-                                image_format = 'docker'
-                            }
-
                             steps {
 
-                                sh '''#!/bin/bash
-                                ${AUTOMATION_BASE_DIR}/setContext.sh || exit $?
-                                '''
+                                dir('code/tradetrust/ts-document-store-worker') {
+                                    sh '''#!/bin/bash
+                                        hamlet release upload-image -u openatt-worker -f docker \
+                                            -r "${GIT_COMMIT}" --dockerfile Dockerfile --docker-context .
 
-                                script {
-                                    def contextProperties = readProperties interpolate: true, file: "${WORKSPACE}/context.properties";
-                                    contextProperties.each{ k, v -> env["${k}"] ="${v}" }
+                                        hamlet release update-image-reference -u openatt-worker -f docker \
+                                            -r "${GIT_COMMIT}"
+                                    '''
+
+                                    sh '''#!/bin/bash
+                                        hamlet deploy run-deployments -u openatt-worker -u openatt-contract
+                                    '''
                                 }
-
-                                sh '''#!/bin/bash
-                                ${AUTOMATION_DIR}/manageImages.sh -g "${GIT_COMMIT}" -f "${image_format}"  || exit $?
-                                '''
-
-                                script {
-                                    def contextProperties = readProperties interpolate: true, file: "${WORKSPACE}/context.properties";
-                                    contextProperties.each{ k, v -> env["${k}"] ="${v}" }
-                                }
-                                build job: "${env["deploy_stream_job"]}", wait: false, parameters: [
-                                        extendedChoice(name: 'DEPLOYMENT_UNITS', value: "${env.DEPLOYMENT_UNITS}"),
-                                        string(name: 'GIT_COMMIT', value: "${env.GIT_COMMIT}"),
-                                        string(name: 'IMAGE_FORMATS', value: "${env.image_format}"),
-                                        string(name: 'SEGMENT', value: "${env["SEGMENT"]}")
-                                ]
                             }
                         }
 
                         stage('openatt-verify-api') {
-                            environment {
-                                //hamlet deployment variables
-                                DEPLOYMENT_UNITS = 'openatt-verify-api'
-                                SEGMENT = 'clients'
-                                BUILD_PATH = 'artefact/tradetrust/tradetrust/open-attestation-verify-api'
-                                BUILD_SRC_DIR = ''
-                                GENERATION_CONTEXT_DEFINED = ''
-
-                                image_format = 'openapi'
-
-                            }
-
                             steps {
 
-                                dir('artefact/tradetrust/tradetrust/open-attestation-verify-api') {
+                                dir('code/tradetrust/open-attestation-verify-api') {
                                     sh '''
-                                        npm ci
-                                        npx swagger-cli bundle -t json -o openapi-extended-base.json api.yml
+                                        npx swagger-cli bundle -t json -o build/openapi-extended-base.json api.yml
+                                        npx swagger-cli validate build/openapi-extended-base.json
+                                    '''
 
-                                        zip -j "openapi.zip" "openapi-extended-base.json"
-                                        mkdir -p src/dist/
-                                        cp "openapi.zip" src/dist/openapi.zip
+                                    sh '''
+                                        hamlet release upload-image -u openatt-verify-api -f openapi -r "${GIT_COMMIT}" \
+                                            --image-path build/
+
+                                        hamlet release update-image-reference -u openatt-verify-api -f openapi -r "${GIT_COMMIT}"
+                                    '''
+
+                                    sh '''
+                                        hamlet deploy run-deployments -u openatt-verify-api
                                     '''
                                 }
-
-                                sh '''#!/bin/bash
-                                ${AUTOMATION_BASE_DIR}/setContext.sh || exit $?
-                                '''
-
-                                script {
-                                    def contextProperties = readProperties interpolate: true, file: "${WORKSPACE}/context.properties";
-                                    contextProperties.each{ k, v -> env["${k}"] ="${v}" }
-                                }
-
-                                sh '''#!/bin/bash
-                                ${AUTOMATION_DIR}/manageImages.sh -g "${GIT_COMMIT}" -f "${image_format}"  || exit $?
-                                '''
-
-                                script {
-                                    def contextProperties = readProperties interpolate: true, file: "${WORKSPACE}/context.properties";
-                                    contextProperties.each{ k, v -> env["${k}"] ="${v}" }
-                                }
-
-                                build job: "${env["deploy_stream_job"]}", wait: false, parameters: [
-                                        extendedChoice(name: 'DEPLOYMENT_UNITS', value: "${env.DEPLOYMENT_UNITS}"),
-                                        string(name: 'GIT_COMMIT', value: "${env.GIT_COMMIT}"),
-                                        string(name: 'IMAGE_FORMATS', value: "${env.image_format}"),
-                                        string(name: 'SEGMENT', value: "${env["SEGMENT"]}")
-                                ]
                             }
                         }
 
                         stage('openatt-verify-api-imp') {
-                            environment {
-                                //hamlet deployment variables
-                                DEPLOYMENT_UNITS = 'openatt-verify-api-imp'
-                                SEGMENT = 'clients'
-                                GENERATION_CONTEXT_DEFINED = ''
-                                BUILD_PATH = 'artefact/tradetrust/tradetrust/open-attestation-verify-api'
-                                BUILD_SRC_DIR = ''
-
-                                image_format = 'lambda'
-                            }
-
                             steps {
 
-                                dir('artefact/tradetrust/tradetrust/open-attestation-verify-api') {
+                                dir('code/tradetrust/open-attestation-verify-api') {
                                     sh '''#!/bin/bash
                                         npm ci
                                         npx serverless package
-                                        mkdir -p src/dist
-                                        cp .serverless/open-attestation-verify-api.zip src/dist/lambda.zip
+                                    '''
+
+                                    sh '''#!/bin/bash
+                                        hamlet release upload-image -u openatt-verify-api-imp -f lambda \
+                                            -r "${GIT_COMMIT}" --image-path .serverless/open-attestation-verify-api.zip
+
+                                        hamlet release update-image-reference -u openatt-verify-api-imp -f lambda \
+                                            -r "${GIT_COMMIT}"
+                                    '''
+
+                                    sh '''#!/bin/bash
+                                        hamlet deploy run-deployments -u openatt-verify-api-imp
                                     '''
                                 }
-
-                                sh '''#!/bin/bash
-                                ${AUTOMATION_BASE_DIR}/setContext.sh || exit $?
-                                '''
-
-                                script {
-                                    def contextProperties = readProperties interpolate: true, file: "${WORKSPACE}/context.properties";
-                                    contextProperties.each{ k, v -> env["${k}"] ="${v}" }
-                                }
-
-                                sh '''#!/bin/bash
-                                ${AUTOMATION_DIR}/manageImages.sh -g "${GIT_COMMIT}" -f "${image_format}"  || exit $?
-                                '''
-
-                                script {
-                                    def contextProperties = readProperties interpolate: true, file: "${WORKSPACE}/context.properties";
-                                    contextProperties.each{ k, v -> env["${k}"] ="${v}" }
-                                }
-
-                                build job: "${env["deploy_stream_job"]}", wait: false, parameters: [
-                                        extendedChoice(name: 'DEPLOYMENT_UNITS', value: "${env.DEPLOYMENT_UNITS}"),
-                                        string(name: 'GIT_COMMIT', value: "${env.GIT_COMMIT}"),
-                                        string(name: 'IMAGE_FORMATS', value: "${env.image_format}"),
-                                        string(name: 'SEGMENT', value: "${env["SEGMENT"]}")
-                                ]
                             }
                         }
 
                         stage('openatt-eth-mon') {
-                            environment {
-                                //hamlet deployment variables
-                                DEPLOYMENT_UNITS = 'openatt-eth-mon'
-                                SEGMENT = 'clients'
-                                BUILD_PATH = 'artefact/tradetrust/tradetrust/monitoring'
-                                BUILD_SRC_DIR = ''
-                                GENERATION_CONTEXT_DEFINED = ''
-
-                                image_format = 'lambda'
-                            }
-
                             steps {
 
-                                dir('artefact/tradetrust/tradetrust/monitoring') {
+                                dir('code/tradetrust/monitoring') {
                                     sh '''#!/bin/bash
                                         current_py="$( pyenv global )"
                                         pyenv install 3.8.0
@@ -552,37 +424,22 @@ pipeline {
 
                                         npm ci
                                         npx serverless package
-                                        mkdir -p src/dist
-                                        cp .serverless/tradetrust-monitoring.zip src/dist/lambda.zip
 
                                         pyenv global "${current_py}"
                                     '''
+
+                                    sh '''#!/bin/bash
+                                        hamlet release upload-image -u openatt-eth-mon -f lambda \
+                                            -r "${GIT_COMMIT}" --image-path .serverless/tradetrust-monitoring.zip
+
+                                        hamlet release update-image-reference -u openatt-eth-mon -f lambda \
+                                            -r "${GIT_COMMIT}"
+                                    '''
+
+                                    sh '''#!/bin/bash
+                                        hamlet deploy run-deployments -u openatt-eth-mon
+                                    '''
                                 }
-
-                                sh '''#!/bin/bash
-                                ${AUTOMATION_BASE_DIR}/setContext.sh || exit $?
-                                '''
-
-                                script {
-                                    def contextProperties = readProperties interpolate: true, file: "${WORKSPACE}/context.properties";
-                                    contextProperties.each{ k, v -> env["${k}"] ="${v}" }
-                                }
-
-                                sh '''#!/bin/bash
-                                ${AUTOMATION_DIR}/manageImages.sh -g "${GIT_COMMIT}" -f "${image_format}"  || exit $?
-                                '''
-
-                                script {
-                                    def contextProperties = readProperties interpolate: true, file: "${WORKSPACE}/context.properties";
-                                    contextProperties.each{ k, v -> env["${k}"] ="${v}" }
-                                }
-
-                                build job: "${env["deploy_stream_job"]}", wait: false, parameters: [
-                                        extendedChoice(name: 'DEPLOYMENT_UNITS', value: "${env.DEPLOYMENT_UNITS}"),
-                                        string(name: 'GIT_COMMIT', value: "${env.GIT_COMMIT}"),
-                                        string(name: 'IMAGE_FORMATS', value: "${env.image_format}"),
-                                        string(name: 'SEGMENT', value: "${env["SEGMENT"]}")
-                                ]
                             }
                         }
                     }
@@ -590,7 +447,7 @@ pipeline {
                     post {
                         success {
                             slackSend (
-                                message: "*Success* | <${BUILD_URL}|${JOB_NAME}> \n Tradetrust artefact completed",
+                                message: "*Success* | <${BUILD_URL}|${JOB_NAME}> \n Tradetrust deployment completed",
                                 channel: "${env["slack_channel"]}",
                                 color: "#50C878"
                             )
@@ -598,102 +455,26 @@ pipeline {
 
                         failure {
                             slackSend (
-                                message: "*Failure* | <${BUILD_URL}|${JOB_NAME}> \n Tradetrust artefact failed",
+                                message: "*Failure* | <${BUILD_URL}|${JOB_NAME}> \n Tradetrust deployment failed",
                                 channel: "${env["slack_channel"]}",
                                 color: "#B22222"
                             )
                         }
                     }
                 }
+            }
 
-                stage('plunger') {
+            post {
+                always {
+                    withCredentials([gitUsernamePassword(credentialsId: 'github')]) {
+                        sh '''
+                            git config --global user.name "JenkinsPipeline"
+                            git config --global user.email "${CHANGE_AUTHOR_EMAIL:-Jenkins@pipeline.local}"
 
-                    when {
-                        anyOf {
-                            equals expected: true, actual: params.force_deploy
-                            branch 'master'
-                            branch 'main'
-                        }
-                    }
-
-                    stages{
-                        stage('Setup') {
-                            steps {
-                                dir('artefact/plunger/') {
-                                    script {
-                                        def productProperties = readProperties interpolate: true, file: "${env.properties_file}";
-                                        productProperties.each{ k, v -> env["${k}"] ="${v}" }
-
-                                        repo = checkout scm
-                                        env["GIT_COMMIT"] = repo.GIT_COMMIT
-                                    }
-                                }
-                            }
-                        }
-
-                        stage('plunger-task') {
-
-                            environment {
-                                //hamlet deployment variables
-                                DEPLOYMENT_UNITS = 'openatt-plunger'
-                                SEGMENT = 'clients'
-                                BUILD_PATH = 'artefact/plunger/trade_portal/scripts/plunger'
-                                BUILD_SRC_DIR = ''
-                                DOCKER_CONTEXT_DIR = 'artefact/plunger/trade_portal/scripts/plunger'
-                                DOCKER_FILE = 'artefact/plunger/trade_portal/scripts/plunger/Dockerfile'
-                                GENERATION_CONTEXT_DEFINED = ''
-
-                                image_format = 'docker'
-                            }
-
-                            steps {
-
-                                sh '''#!/bin/bash
-                                ${AUTOMATION_BASE_DIR}/setContext.sh || exit $?
-                                '''
-
-                                script {
-                                    def contextProperties = readProperties interpolate: true, file: "${WORKSPACE}/context.properties";
-                                    contextProperties.each{ k, v -> env["${k}"] ="${v}" }
-                                }
-
-                                sh '''#!/bin/bash
-                                ${AUTOMATION_DIR}/manageImages.sh -g "${GIT_COMMIT}" -f "${image_format}"  || exit $?
-                                '''
-
-                                script {
-                                    def contextProperties = readProperties interpolate: true, file: "${WORKSPACE}/context.properties";
-                                    contextProperties.each{ k, v -> env["${k}"] ="${v}" }
-                                }
-                                build job: "${env["deploy_stream_job"]}", wait: false, parameters: [
-                                        extendedChoice(name: 'DEPLOYMENT_UNITS', value: "${env.DEPLOYMENT_UNITS}"),
-                                        string(name: 'GIT_COMMIT', value: "${env.GIT_COMMIT}"),
-                                        string(name: 'IMAGE_FORMATS', value: "${env.image_format}"),
-                                        string(name: 'SEGMENT', value: "${env["SEGMENT"]}")
-                                ]
-                            }
-                        }
-                    }
-
-                    post {
-                        success {
-                            slackSend (
-                                message: "*Success* | <${BUILD_URL}|${JOB_NAME}> \n Plugner artefact completed",
-                                channel: "${env["slack_channel"]}",
-                                color: "#50C878"
-                            )
-                        }
-
-                        failure {
-                            slackSend (
-                                message: "*Failure* | <${BUILD_URL}|${JOB_NAME}> \n Plugner artefact failed",
-                                channel: "${env["slack_channel"]}",
-                                color: "#B22222"
-                            )
-                        }
+                            hamlet cmdb commit-changes --products --commit-message "${BUILD_TAG}" --branch "${product_cmdb_branch}"
+                        '''
                     }
                 }
-
             }
         }
     }


### PR DESCRIPTION
- Full CI/CD process included in pipelines
- Removes some of the build path configuration requirements that
were specific to hamlet
- Use folder properties for environment context setting