### PR TITLE
Seperate oa wrap and sign

### DIFF
--- a/trade_portal/trade_portal/documents/services/lodge.py
+++ b/trade_portal/trade_portal/documents/services/lodge.py
@@ -64,7 +64,8 @@ class DocumentService:
         # TODO: think about replacing by native solution (won't give much performance increase)
         # https://github.com/Open-Attestation/open-attestation/blob/master/src/2.0/wrap.ts#L25
         try:
-            oa_doc_wrapped_resp = self.oa_client.wrap_document(oa_doc)
+            oa_doc_wrapped_resp_0 = self.oa_client.wrap_document(oa_doc)
+            oa_doc_wrapped_resp = self.oa_client.sign_document(oa_doc_wrapped_resp_0.json())
             if oa_doc_wrapped_resp.status_code != 200:
                 # this is not common to have API answering non-200
                 logger.warning("Received %s for oa doc wrap step", oa_doc_wrapped_resp)

--- a/trade_portal/trade_portal/documents/services/oa.py
+++ b/trade_portal/trade_portal/documents/services/oa.py
@@ -25,6 +25,16 @@ class OaApiRestClient:
             },
         )
 
+    def sign_document(self, oa_doc):
+        if getattr(settings, "IS_UNITTEST", False) is True: #Copied from wrap_document
+            raise EnvironmentError("This procedure must not be called from unittest")
+        return requests.post(
+            settings.OA_WRAP_API_URL + "/document/sign",
+            json={
+                "document": oa_doc,
+            },
+        )
+
 
 class OaV2Renderer:
 

--- a/tradetrust/open-attestation-api/src/app.js
+++ b/tradetrust/open-attestation-api/src/app.js
@@ -17,9 +17,10 @@ const {
 
 const KMS = new AWS.KMS();
 
-const DEFAULT_WRAP_PARAMS = {
-  version: 'https://schema.openattestation.com/3.0/schema.json'
+const DEFAULT_WRAP_PARAMS = { //Morgan: This currently does nothing in OA, despite what docs say!
+  version: 'https://schema.openattestation.com/3.0/schema.json'  
 };
+
 
 
 function create(){
@@ -42,19 +43,58 @@ function create(){
     logger.error(err);
   }
 
-  app.post('/document/wrap', async function (req, res){
+  
+  app.post("/document/sign", async function(req,res){
+    console.log('/document/sign')
+    if (req.body.document === undefined){throw new UserFriendlyError('No "document" field in payload');}
+    const document = req.body.document; //should be wrapped already at this point
+
+    var keyPair;
+    if(!process.env.DOCUMENT_STORE_OWNER_PRIVATE_KEY){
+      keyPair = {
+        private: '0x40b639e8fb83afe8ad8d4bb7857e69d039a15c3e476b2d98f346222623420e6f',
+        public: '0x103D912298C89a98Eed323376aa4403b92b28842'
+      }
+    }
+    else{
+      keyPair = {
+        //public: `did:ethr:${publicKey}#controller`,
+        public: process.env.DOCUMENT_STORE_OWNER_PUBLIC_KEY,
+        private: process.env.DOCUMENT_STORE_OWNER_PRIVATE_KEY
+      };
+    }
+
+
+    const signedDocument = await signDocument(document, 
+          SUPPORTED_SIGNING_ALGORITHM.Secp256k1VerificationKey2018, 
+          keyPair);
+
+    // Verification- probably not necessary
+    if (!verifySignature(signedDocument)){
+      console.log("Signing not validated immediately after signing.");
+    }
+    console.log(JSON.stringify(signedDocument, null, 2)); 
+    
+    res.status(200).send(signedDocument);
+
+  });
+  app.post("/document/wrap", async function (req, res){
     if (req.body.document === undefined){throw new UserFriendlyError('No "document" field in payload');}
     const document = req.body.document;
     const params = {...DEFAULT_WRAP_PARAMS, ...(req.body.params || {})};
     try{
       const wrappedDocument = wrapDocument(document, params);
+      res.status(200).send(wrappedDocument);
+      /*
       console.log("document wrapped")
       console.log(wrappedDocument)
+      // Previously  finished here: res.status(200).send(wrappedDocument);
       // get sigining key
       const pkEnv = process.env.DOCUMENT_STORE_OWNER_PRIVATE_KEY||'';
       const b64String = pkEnv.slice("kms+base64:".length)
       console.log(b64String);
       const data = Buffer.from(b64String, 'base64');
+
 
       console.log("attempting to decrypt private key")
       try{
@@ -73,15 +113,17 @@ function create(){
         console.log(JSON.stringify(signedDocument, null, 2));
         
         res.status(200).send(signedDocument);
-      } catch(e){
+      } 
+      catch(e){
         console.log("failed to either decrypt key or sign document")
         console.log(e)
       }
+      */
       
     }catch(e){
       let error = e.message;
       if (e.validationErrors) {
-        error = JSON.stringify(e.validationErrors)
+         error = JSON.stringify(e.validationErrors) //Morgan: I suspect this is vestigial?
       }
       throw new UserFriendlyError(error);
     }


### PR DESCRIPTION
Splitting the OA document wrapping step into seperate wrapping and signing steps

* added a method/endpoint for signing in open-attestation-api app.js.
* Added a sign_document method to OaApiRestClient in oa.py
* The sign_document method is now called immediately after wrap_document in DocumentService.issue(). 
* No error checking or testing added as yet, but checked to work manually